### PR TITLE
[feat] 카카오 로그인 및 회원가입 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,12 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok")
     testAndDevelopmentOnly("org.springframework.boot:spring-boot-docker-compose")
     testAnnotationProcessor("org.projectlombok:lombok")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/tripmate/api/config/WebSecurityConfig.java
+++ b/src/main/java/com/tripmate/api/config/WebSecurityConfig.java
@@ -1,5 +1,9 @@
 package com.tripmate.api.config;
 
+import com.tripmate.api.entity.UserRepository;
+import com.tripmate.api.login.JwtAuthFilter;
+import com.tripmate.api.login.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,10 +11,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class WebSecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -18,9 +27,11 @@ public class WebSecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(
                         requests -> requests
-                                .requestMatchers("/api/v1/*", "/health/**", "/v1/**", "/swagger-ui/**").permitAll()
+                                .requestMatchers("/api/v1/**", "/health/**", "/v1/**", "/swagger-ui/**", "/view/**", "/api/**","/css/**", "/error/**").permitAll()
                                 .anyRequest().authenticated()
                 );
+
+        http.addFilterBefore(new JwtAuthFilter(jwtTokenProvider,userRepository), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/tripmate/api/entity/UserEntity.java
+++ b/src/main/java/com/tripmate/api/entity/UserEntity.java
@@ -1,0 +1,28 @@
+package com.tripmate.api.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserEntity {
+
+    @Id
+    private Long kakaoId;
+
+    @NotNull
+    private String nickname;
+    @NotNull
+    private String profileImage;
+    @NotNull
+    private String thumbnailImage;
+
+}

--- a/src/main/java/com/tripmate/api/entity/UserRepository.java
+++ b/src/main/java/com/tripmate/api/entity/UserRepository.java
@@ -1,0 +1,9 @@
+package com.tripmate.api.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+}

--- a/src/main/java/com/tripmate/api/login/JwtAuthFilter.java
+++ b/src/main/java/com/tripmate/api/login/JwtAuthFilter.java
@@ -1,0 +1,43 @@
+package com.tripmate.api.login;
+
+import com.tripmate.api.entity.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        //JWT가 헤더에 있는 경우
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            //JWT 유효성 검증
+            if (jwtTokenProvider.validateToken(token)) {
+                Long userId = Long.valueOf(jwtTokenProvider.getInfoFromToken(token).getId());
+                if (userRepository.existsById(userId)) {
+                    filterChain.doFilter(request, response); // 다음 필터로 넘기기
+                    return;
+                }
+            }
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Unauthorized: Invalid or missing JWT token");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/tripmate/api/login/JwtTokenProvider.java
+++ b/src/main/java/com/tripmate/api/login/JwtTokenProvider.java
@@ -1,0 +1,84 @@
+package com.tripmate.api.login;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessTokenExpTime;
+
+    public JwtTokenProvider(
+        @Value("${jwt.key}") String secretKey,
+        @Value("${jwt.access_token_expiration}") long accessTokenExpTime) {
+
+        String encode = Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
+        byte[] keyBytes = Decoders.BASE64.decode(encode);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
+    }
+
+    /**
+     * JWT 생성
+     */
+    public String createToken(LoginJwtInputDto inputDto) {
+
+        HashMap<String, String> claims = new HashMap<>();
+
+        claims.put("id", String.valueOf(inputDto.getId()));
+        claims.put("nickname", inputDto.getNickname());
+        claims.put("thumbnailImageUrl", inputDto.getThumbnailImageUrl());
+        claims.put("profileImageUrl", inputDto.getProfileImageUrl());
+
+        Date now = new Date();
+
+        return Jwts.builder()
+            .claims(claims)
+            .issuedAt(now)
+            .expiration(new Date(now.getTime() + accessTokenExpTime))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    /**
+     * 토큰 유효성 확인
+     */
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                .setSigningKey(key)  // 서명 검증을 위한 키 설정
+                .build()
+                .parseClaimsJws(token)  // 토큰을 파싱하여 클레임을 가져옴
+                .getBody();
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰 정보 확인
+     */
+    public Claims getInfoFromToken(String token) {
+
+        return Jwts.parser()
+            .setSigningKey(key)  // 서명 검증을 위한 키 설정
+            .build()
+            .parseClaimsJws(token)  // 토큰을 파싱하여 클레임을 가져옴
+            .getBody();
+
+    }
+
+
+}

--- a/src/main/java/com/tripmate/api/login/KakaoLoginService.java
+++ b/src/main/java/com/tripmate/api/login/KakaoLoginService.java
@@ -1,0 +1,109 @@
+package com.tripmate.api.login;
+
+
+import com.tripmate.api.entity.UserEntity;
+import com.tripmate.api.entity.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoLoginService {
+
+
+    @Value("${REST_API_KEY}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String KAUTH_TOKEN_URL_HOST;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String REDIRECT_URI;
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 인가코드로 엑세스토큰 받아오는 메서드
+     */
+    public String getAccessTokenFromKakao(String code) {
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientId);
+        formData.add("redirect_uri", REDIRECT_URI);
+        formData.add("code", code);
+
+        KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData(formData))
+            .retrieve()
+            .bodyToMono(KakaoTokenResponseDto.class)
+            .block();
+
+        UserEntity user = getUserInfoFromKakao(kakaoTokenResponseDto.getAccessToken());
+
+        LoginJwtInputDto loginJwtInputDto = LoginJwtInputDto.builder()
+            .id(user.getKakaoId())
+            .profileImageUrl(user.getProfileImage())
+            .thumbnailImageUrl(user.getThumbnailImage())
+            .nickname(user.getNickname())
+            .build();
+
+        String token = jwtTokenProvider.createToken(loginJwtInputDto);
+        return token;
+    }
+
+    /**
+     * 유저 정보 가져오는 메서드
+     */
+    public UserEntity getUserInfoFromKakao(String accessToken) {
+
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+
+        KakaoUserInfoResponseDto kakaoUserInfoResponseDto = WebClient.create(userInfoUrl).get()
+            .headers(httpHeaders -> {
+                httpHeaders.add("Authorization", "Bearer " + accessToken);
+                httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+            })
+            .retrieve()
+            .bodyToMono(KakaoUserInfoResponseDto.class)
+            .block();
+
+        UserEntity userEntity = doKakaoAutoLogin(kakaoUserInfoResponseDto);
+
+        return userEntity;
+    }
+
+    /**
+     * 자동 로그인 & 회원가입 메서드
+     *
+     */
+    public UserEntity doKakaoAutoLogin(KakaoUserInfoResponseDto responseDto) {
+
+        Long kakaoId = responseDto.getId();
+        Optional<UserEntity> user = userRepository.findById(kakaoId);
+
+        if (user.isPresent()) {
+            return user.get();
+        }
+
+        UserEntity userEntity = UserEntity.builder()
+            .kakaoId(kakaoId)
+            .nickname(responseDto.getKakaoNickname())
+            .profileImage(responseDto.getProfileImageUrl())
+            .thumbnailImage(responseDto.getThumbnailImageUrl()).build();
+        userRepository.save(userEntity);
+
+        return userEntity;
+    }
+
+}

--- a/src/main/java/com/tripmate/api/login/KakaoTokenResponseDto.java
+++ b/src/main/java/com/tripmate/api/login/KakaoTokenResponseDto.java
@@ -1,0 +1,39 @@
+package com.tripmate.api.login;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("token_type")
+    public String tokenType;
+
+    @JsonProperty("access_token")
+    public String accessToken;
+
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+
+    @Override
+    public String toString() {
+        return "KakaoTokenResponseDto{" +
+            "tokenType='" + tokenType + '\'' +
+            ", accessToken='" + accessToken + '\'' +
+            ", expiresIn=" + expiresIn +
+            ", refreshToken='" + refreshToken + '\'' +
+            ", refreshTokenExpiresIn=" + refreshTokenExpiresIn +
+            '}';
+    }
+
+}

--- a/src/main/java/com/tripmate/api/login/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/tripmate/api/login/KakaoUserInfoResponseDto.java
@@ -1,0 +1,55 @@
+package com.tripmate.api.login;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+
+    @JsonProperty("id")
+    private Long id;  // 회원번호
+
+    @JsonProperty("kakao_account")
+    private KakaoAccountDto kakaoAccount;  // 카카오 계정 정보
+
+    public String getKakaoNickname() {
+        return kakaoAccount.profile.getNickname();
+    }
+    public String getThumbnailImageUrl() {
+        return kakaoAccount.profile.getThumbnailImageUrl();
+    }
+    public String getProfileImageUrl() {
+        return kakaoAccount.profile.getProfileImageUrl();
+    }
+
+
+    @Override
+    public String toString() {
+        return "KakaoUserInfoResponseDto{" +
+            "id=" + id +
+            ", kakaoAccount=" + kakaoAccount +
+            '}';
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private static class KakaoAccountDto {
+
+        private KakaoProfile profile;
+
+        @Getter
+        @NoArgsConstructor
+        private static class KakaoProfile {
+
+            private String nickname;
+            @JsonProperty("thumbnail_image_url")
+            private String thumbnailImageUrl;
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+}

--- a/src/main/java/com/tripmate/api/login/LoginController.java
+++ b/src/main/java/com/tripmate/api/login/LoginController.java
@@ -1,0 +1,35 @@
+package com.tripmate.api.login;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1")
+public class LoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @GetMapping("/oauth/check")
+    public ResponseEntity<?> kakaoLogin(@RequestParam("code") String code) {
+
+        String token = kakaoLoginService.getAccessTokenFromKakao(code);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+
+        LoginResponseDto responseDto = LoginResponseDto.builder()
+            .token(token).build();
+
+        return new ResponseEntity<>(responseDto, headers, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/tripmate/api/login/LoginJwtInputDto.java
+++ b/src/main/java/com/tripmate/api/login/LoginJwtInputDto.java
@@ -1,0 +1,18 @@
+package com.tripmate.api.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginJwtInputDto {
+
+    private Long id;
+    private String nickname;
+    private String thumbnailImageUrl;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/tripmate/api/login/LoginResponseDto.java
+++ b/src/main/java/com/tripmate/api/login/LoginResponseDto.java
@@ -1,0 +1,16 @@
+package com.tripmate.api.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginResponseDto {
+
+    private String token;
+
+}

--- a/src/main/java/com/tripmate/api/login/ViewLoginController.java
+++ b/src/main/java/com/tripmate/api/login/ViewLoginController.java
@@ -1,0 +1,30 @@
+package com.tripmate.api.login;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/view")
+public class ViewLoginController {
+
+    @Value("${REST_API_KEY}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @GetMapping("/login")
+    public String login(Model model) {
+        model.addAttribute("clientId", clientId);
+        model.addAttribute("redirectUri", redirectUri);
+        return "login";
+    }
+
+    @GetMapping("/home")
+    public String home() {
+        return "home";
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,8 @@ spring:
   config:
     import: optional:file:.env[.properties]
   datasource:
-    url: jdbc:mysql://localhost:3306/tripmate
+#    url: jdbc:mysql://localhost:3306/tripmate
+    url: jdbc:mysql://mysql:3306/tripmate
     username: tripmate
     password: tripmate
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,6 +13,22 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${REST_API_KEY}  # 카카오 REST API 키
+            redirect-uri: ${baseUrl}/api/v1/oauth/check
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, profile_image
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 springdoc:
   swagger-ui:
@@ -32,3 +49,11 @@ integration:
     service-key: ${TOUR_API_SERVICE_KEY}
     mobile-app: ${TOUR_API_MOBILE_APP}
     mobile-os: ${TOUR_API_MOBILE_OS}
+
+baseUrl: http://localhost:8080
+REST_API_KEY: e7f1efe776e2eb746c7e64038e45141b
+REDIRECT_URL: ${baseUrl}/view/home
+
+jwt:
+  key: projectKey-which-is-longer-than-32bits-complete
+  access_token_expiration: 86400000 # 1일

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Home</title>
+</head>
+<body>
+<h1>Home</h1>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<a href="#" th:href="@{/oauth2/authorization/kakao}">카카오로 로그인</a>
+
+<a th:href="@{'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=' + ${clientId} + '&redirect_uri=' + ${redirectUri}}">
+  카카오 로그인
+</a>
+</body>
+</html>


### PR DESCRIPTION

> Issue number/link

# 개요
카카오 로그인 및 회원가입 구현
JWT 필터로 확인 절차 구현

# 개선/변경 사항
- application.yml 내 url 변경
- 패키지 구조는 추후 refactoring 예정
- 로그인 후 필요한 주요 정보는 JWT에 담아 헤더로 주고받음

# 고민/어려웠던 점
- refactoring 및 개선 필요
- 급한 마감으로 빠르게 구현만한 상황