### PR TITLE
[Feat] 회원탈퇴, 마이페이지 정보 조회 API, 동행 리뷰 생성 서비스 구현

### DIFF
--- a/src/main/java/com/tripmate/api/controller/CompanionController.java
+++ b/src/main/java/com/tripmate/api/controller/CompanionController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,8 +56,8 @@ public class CompanionController {
         description = ""
     )
     @PostMapping("/review")
-    public ResponseEntity<Void> createCompanionReview(@Valid @RequestBody CompanionReviewRequest companionReviewRequest) {
-
+    public ResponseEntity<Void> createCompanionReview(@AuthenticationPrincipal Long userId, @Valid @RequestBody CompanionReviewRequest companionReviewRequest) {
+        companionService.saveCompanionReview(userId, companionReviewRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
      }
 

--- a/src/main/java/com/tripmate/api/dto/request/WithdrawalRequest.java
+++ b/src/main/java/com/tripmate/api/dto/request/WithdrawalRequest.java
@@ -1,0 +1,7 @@
+package com.tripmate.api.dto.request;
+
+public record WithdrawalRequest(
+    Long id
+) {
+
+}

--- a/src/main/java/com/tripmate/api/dto/response/MypageUserInfoResponse.java
+++ b/src/main/java/com/tripmate/api/dto/response/MypageUserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.tripmate.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record MypageUserInfoResponse(
+
+    @Schema(description = "유저가 선택했던 키워드")
+    List<String> selectedKeyword,
+
+    @Schema(description = "캐릭터 id")
+    Long characterId,
+
+    @Schema(description = "여행 스타일")
+    String tripStyle
+) {
+
+}

--- a/src/main/java/com/tripmate/api/entity/CompanionReviewEntity.java
+++ b/src/main/java/com/tripmate/api/entity/CompanionReviewEntity.java
@@ -1,0 +1,33 @@
+package com.tripmate.api.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CompanionReviewEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long companionId;
+
+    private String feedback;
+
+    private boolean isPositive;
+
+}

--- a/src/main/java/com/tripmate/api/entity/CompanionReviewRepository.java
+++ b/src/main/java/com/tripmate/api/entity/CompanionReviewRepository.java
@@ -1,0 +1,9 @@
+package com.tripmate.api.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanionReviewRepository extends JpaRepository<CompanionReviewEntity, Long> {
+
+}

--- a/src/main/java/com/tripmate/api/entity/UserEntity.java
+++ b/src/main/java/com/tripmate/api/entity/UserEntity.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -24,5 +25,12 @@ public class UserEntity {
     private String profileImage;
     @NotNull
     private String thumbnailImage;
+
+    @ColumnDefault("false")
+    private boolean deleted;
+
+    public void deleteAccount() {
+        this.deleted = true;
+    }
 
 }

--- a/src/main/java/com/tripmate/api/login/JwtAuthFilter.java
+++ b/src/main/java/com/tripmate/api/login/JwtAuthFilter.java
@@ -1,13 +1,17 @@
 package com.tripmate.api.login;
 
 import com.tripmate.api.entity.UserRepository;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
@@ -28,8 +32,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String token = authorizationHeader.substring(7);
             //JWT 유효성 검증
             if (jwtTokenProvider.validateToken(token)) {
-                Long userId = Long.valueOf(jwtTokenProvider.getInfoFromToken(token).getId());
+                Claims infoFromToken = jwtTokenProvider.getInfoFromToken(token);
+                Long userId = Long.valueOf(infoFromToken.get("id", String.class));
                 if (userRepository.existsById(userId)) {
+                    // securityContext에 유저 정보 저장
+                    UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                        userId, null, Collections.emptyList());
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                     filterChain.doFilter(request, response); // 다음 필터로 넘기기
                     return;
                 }

--- a/src/main/java/com/tripmate/api/login/KakaoLoginService.java
+++ b/src/main/java/com/tripmate/api/login/KakaoLoginService.java
@@ -162,4 +162,10 @@ public class KakaoLoginService {
         userRepository.save(user);
     }
 
+    /**
+     * 마이페이지 유저 정보 가져오는 메서드
+     */
+    public void getMypageUserInfo(Long userId) {
+
+    }
 }

--- a/src/main/java/com/tripmate/api/login/KakaoLoginService.java
+++ b/src/main/java/com/tripmate/api/login/KakaoLoginService.java
@@ -3,6 +3,7 @@ package com.tripmate.api.login;
 
 import com.tripmate.api.entity.UserEntity;
 import com.tripmate.api.entity.UserRepository;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -142,6 +143,23 @@ public class KakaoLoginService {
             .build();
 
         return jwtTokenProvider.createToken(loginJwtInputDto);
+    }
+
+
+    /**
+     * 회원탈퇴 메서드
+     * 활성 유저면 soft delete 진행
+     */
+    public void doWithdrawal(Long id) {
+
+        UserEntity user = userRepository.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다", null));
+        if (user.isDeleted()) {
+            throw new NoSuchElementException("존재하지 않는 회원입니다", null);
+        }
+        user.deleteAccount();
+
+        userRepository.save(user);
     }
 
 }

--- a/src/main/java/com/tripmate/api/login/LoginController.java
+++ b/src/main/java/com/tripmate/api/login/LoginController.java
@@ -1,6 +1,8 @@
 package com.tripmate.api.login;
 
 import com.tripmate.api.dto.request.WithdrawalRequest;
+import com.tripmate.api.dto.response.MypageUserInfoResponse;
+import com.tripmate.api.dto.response.TripmateApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -62,5 +66,16 @@ public class LoginController {
         kakaoLoginService.doWithdrawal(withdrawalRequest.id());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(
+        summary = "마이페이지 - 유저 정보 확인 API"
+    )
+    @GetMapping("user/{userId}")
+    public ResponseEntity<TripmateApiResponse<MypageUserInfoResponse>> getUserInfo(@PathVariable("userId") Long userId) {
+
+        kakaoLoginService.getMypageUserInfo(userId);
+
+        return null;
     }
 }

--- a/src/main/java/com/tripmate/api/login/LoginController.java
+++ b/src/main/java/com/tripmate/api/login/LoginController.java
@@ -1,5 +1,6 @@
 package com.tripmate.api.login;
 
+import com.tripmate.api.dto.request.WithdrawalRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -7,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class LoginController {
 
     private final KakaoLoginService kakaoLoginService;
 
-    @GetMapping("/oauth/check")
+//    @GetMapping("/oauth/check")
     public ResponseEntity<?> kakaoLoginGet(@RequestParam("code") String code) {
 
         String token = kakaoLoginService.getAccessTokenFromKakao(code);
@@ -50,5 +50,17 @@ public class LoginController {
         headers.add("Authorization", "Bearer " + token);
 
         return ResponseEntity.status(HttpStatus.CREATED).headers(headers).build();
+    }
+
+    @Operation(
+        summary = "회원탈퇴 API",
+        description = ""
+    )
+    @PostMapping("/user/withdrawal")
+    public ResponseEntity<Void> userWithdrawal(@Valid @RequestBody WithdrawalRequest withdrawalRequest) {
+
+        kakaoLoginService.doWithdrawal(withdrawalRequest.id());
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/tripmate/api/service/CompanionService.java
+++ b/src/main/java/com/tripmate/api/service/CompanionService.java
@@ -1,22 +1,29 @@
 package com.tripmate.api.service;
 
 import com.tripmate.api.dto.request.CollectCompanionRequest;
+import com.tripmate.api.dto.request.CompanionReviewRequest;
 import com.tripmate.api.dto.response.CompanionInfoResponse;
 import com.tripmate.api.entity.CompanionEntity;
 import com.tripmate.api.entity.CompanionRepository;
+import com.tripmate.api.entity.CompanionReviewEntity;
+import com.tripmate.api.entity.CompanionReviewRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class CompanionService {
 
     private final ModelMapper modelMapper;
     private final CompanionRepository companionRepository;
+    private final CompanionReviewRepository companionReviewRepository;
 
     public CompanionInfoResponse getCompanionInfo(Long companionId) {
         Optional<CompanionEntity> companion = companionRepository.findById(companionId);
@@ -49,6 +56,36 @@ public class CompanionService {
 //        CompanionEntity companionEntity = modelMapper.map(collectCompanionRequest, CompanionEntity.class);
 
         companionRepository.save(companionEntity);
+    }
+
+    /**
+     * 동행 리뷰 저장 메서드
+     * @param userId
+     * @param companionReviewRequest
+     */
+    public void saveCompanionReview(Long userId, CompanionReviewRequest companionReviewRequest) {
+
+        Long companionId = companionReviewRequest.companionId();
+        List<String> likeList = companionReviewRequest.likeList();
+        List<String> badList = companionReviewRequest.badList();
+
+        for (String like : likeList) {
+            CompanionReviewEntity cre = CompanionReviewEntity.builder()
+                .companionId(companionId)
+                .userId(userId)
+                .feedback(like)
+                .isPositive(true).build();
+            companionReviewRepository.save(cre);
+        }
+
+        for (String bad : badList) {
+            CompanionReviewEntity cre = CompanionReviewEntity.builder()
+                .companionId(companionId)
+                .userId(userId)
+                .feedback(bad)
+                .isPositive(false).build();
+            companionReviewRepository.save(cre);
+        }
     }
 
 }


### PR DESCRIPTION
> Issue number/link

# 개요


# 개선/변경 사항
- 회원탈퇴, 마이페이지 정보 조회 API 초안 개발
- 동행 리뷰 생성 서비스
- JWT로 받은 유저 정보 SC에 저장해서 컨트롤러에서 받을 수 있게 변경

# 고민/어려웠던 점
- 유저 정보 SC 저장 커스텀으로 해서 데이터 더 저장하는 것도 좋을 것 같음